### PR TITLE
Remove white gradient overlay above Read More on Joodle app page

### DIFF
--- a/app/apps/[app_id]/app-view.tsx
+++ b/app/apps/[app_id]/app-view.tsx
@@ -237,10 +237,6 @@ export function AppView(props: AppViewProps) {
               </div>
             )}
           </motion.div>
-
-          {!isDescriptionExpanded && (
-            <div className="from-background absolute bottom-0 left-0 h-32 w-full bg-linear-to-t to-transparent" />
-          )}
         </div>
 
         <button


### PR DESCRIPTION
## What

Removes the purely-cosmetic white-to-transparent gradient fade overlay that sat above the **Read More / Show Less** button on the Joodle app detail page (`app/apps/[app_id]/app-view.tsx`).

## Why

The fade obscured the bottom of the collapsed description. Removing it gives a cleaner read of the truncated text.

## Scope

- Single-file change: deletes the `{!isDescriptionExpanded && (<div ... bg-linear-to-t to-transparent />)}` block.
- The `isDescriptionExpanded` state, its `setIsDescriptionExpanded` toggle (still drives the description height animation), the Read More / Show Less `<button>`, and the wrapping `<div className="relative">` are all left intact.

## Verification

- `npm run build` exits 0 — `✓ Compiled successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)